### PR TITLE
Fix group of lights

### DIFF
--- a/alexaContextProperties.js
+++ b/alexaContextProperties.js
@@ -65,6 +65,12 @@ AlexaContextProperties.prototype.powerLevelStateProperty = function (state) {
  * @param {*} state 
  */
 AlexaContextProperties.prototype.colorStateProperty = function (state) {
+  // color item may receive brightness value
+  if (!isNaN(state)) {
+    var num = parseInt(state);
+    state = '0,0,' + num;
+  }
+
   var hsb = state.split(',');
   var h =  parseInt(hsb[0]);
   var s =  parseFloat(hsb[1]);

--- a/ohConnectorV3.js
+++ b/ohConnectorV3.js
@@ -112,7 +112,6 @@ exports.handleRequest = function (_directive, _context) {
           break;
       }
       break;
-      break;
     case "Alexa.CameraStreamController":
       break;
     default:
@@ -527,24 +526,29 @@ function discoverDevices() {
       }
 
       var propertyMap;
-      var groupTag;
+      var isEndpointGroup = false;
+
       //OH Goups can act as a single Endpoint using its children for capabilities
       if (item.type == 'Group') {
         item.tags.forEach(function(tag){
           //found matching Endpoint tag
-        if(groupMatch = tag.match(GROUP_TAG_PATTERN)){ 
-          log.debug("found group " + groupMatch[0] + " for item " + item.name);  
-          item.members.forEach(function (member) {
-            log.debug("adding  " + member.name + " to group " + item.name);  
-            groupItems.push(member.name);
-            propertyMap = utils.tagsToPropertyMap(member, propertyMap);
-          });
-          //set dispay category for group
-          displayCategories.push(groupMatch[1].toUpperCase());
-          return; //returns forEach
-        }
-      });
-      } else {
+          var groupMatch;
+          if(groupMatch = tag.match(GROUP_TAG_PATTERN)){
+            log.debug("found group " + groupMatch[0] + " for item " + item.name);
+            isEndpointGroup = true;
+            item.members.forEach(function (member) {
+              log.debug("adding  " + member.name + " to group " + item.name);
+              groupItems.push(member.name);
+              propertyMap = utils.tagsToPropertyMap(member, propertyMap);
+            });
+            //set dispay category for group
+            displayCategories.push(groupMatch[1].toUpperCase());
+            return; //returns forEach
+          }
+        });
+      }
+
+      if(!isEndpointGroup) {
         propertyMap = utils.tagsToPropertyMap(item);
       }
 

--- a/test/test_ohConnectorV3.js
+++ b/test/test_ohConnectorV3.js
@@ -3,7 +3,8 @@ var ohv3 = require('../ohConnectorV3.js');
 var rest = require('../rest.js');
 
 describe('ohConnectorV3 Test', function () {
-	describe('discover Items', function () {
+
+	describe('Discovery', function () {
 
 		// mock rest call
 		var input;
@@ -116,6 +117,51 @@ describe('ohConnectorV3 Test', function () {
 			assert.equal(capabilities[1].interface, "Alexa.PowerController");
 			assert.equal(capabilities[2].interface, "Alexa.BrightnessController");
 			assert.equal(capabilities[3].interface, "Alexa.ColorController");
+		});
+	});
+
+	describe('BrightnessController', function() {
+
+		// mock rest call
+		var input;
+		rest.postItemCommand = function(token, itemname, value, success) {
+			success(input);
+		};
+
+		var capture = { "result" : null };
+		var context = { "succeed": function(result) { capture.result = result; }};
+
+		it('set brightness at color item', function () {
+			var input = {
+				"header": {
+					"namespace": "Alexa.BrightnessController",
+					"name": "SetBrightness",
+					"payloadVersion": "3"
+				},
+				"endpoint": {
+					"scope": {
+						"type": "BearerToken",
+						"token": ""
+					},
+					"endpointId": "light1",
+					"cookie": {
+						"propertyMap": "{\"PowerController\":{\"powerState\":{\"parameters\":{},\"itemName\":\"light1\"}},\"BrightnessController\":{\"brightness\":{\"parameters\":{},\"itemName\":\"light1\"}},\"ColorController\":{\"color\":{\"parameters\":{},\"itemName\":\"light1\"}}}"
+					}
+				},
+				"payload": {
+					"brightness": 20
+				}
+			};
+
+			ohv3.handleRequest(input, context);
+
+			var properties = capture.result.context.properties;
+			assert.equal(properties.length, 4);
+			assert.equal(properties[0].name, "powerState");
+			assert.equal(properties[0].value, "ON");
+			assert.equal(properties[1].name, "brightness");
+			assert.equal(properties[1].value, 20);
+			assert.equal(properties[2].name, "color");
 		});
 	});
 });

--- a/test/test_ohConnectorV3.js
+++ b/test/test_ohConnectorV3.js
@@ -10,14 +10,89 @@ describe('ohConnectorV3 Test', function () {
 		rest.getItemsRecursively = function(token, success, failure) {
 			success(input);
 		};
-			
+
 		var directive = { 
 			"header" : { "namespace" : "Alexa.Discovery" } ,
 			"payload" : { "scope" : { "token" : ""} } 
 		};
 		var capture = { "result" : null };
 		var context = { "succeed": function(result) { capture.result = result; }};
-		
+
+		it('tagged light group and its tagged children should be discovered', function () {
+
+			// Group:Switch:OR(ON,OFF) lightGroup ["Lighting"]
+			// Color light1 (lightGroup) ["Lighting"]
+			// Color light2 (lightGroup) ["Lighting"]
+			input = [
+				{
+					"link": "https://localhost:8443/rest/items/light1",
+					"type": "Color",
+					"name": "light1",
+					"category": "lightbulb",
+					"tags": ["Lighting"],
+				},
+				{
+					"link": "https://localhost:8443/rest/items/light2",
+					"type": "Color",
+					"name": "light2",
+					"category": "lightbulb",
+					"tags": ["Lighting"],
+				},
+				{
+					"members": [
+						{
+							"link": "https://localhost:8443/rest/items/light1",
+							"type": "Color",
+							"name": "light1",
+							"category": "lightbulb",
+							"tags": ["Lighting"],
+						},
+						{
+							"link": "https://localhost:8443/rest/items/light2",
+							"type": "Color",
+							"name": "light2",
+							"category": "lightbulb",
+							"tags": ["Lighting"],
+						}
+					],
+					"groupType": "Switch",
+					"function": {
+						"name": "OR",
+						"params": ["ON","OFF"]
+					},
+					"link": "https://localhost:8443/rest/items/lightGroup",
+					"type": "Group",
+					"name": "lightGroup",
+					"category": "switch",
+					"tags": ["Lighting"],
+				}
+			];
+
+			ohv3.handleRequest(directive, context);
+
+			var endpoints = capture.result.event.payload.endpoints;
+			assert.equal(endpoints.length, 3);
+
+			var capabilities = endpoints[0].capabilities;
+			assert.equal(capabilities.length, 4);
+			assert.equal(capabilities[0].interface, "Alexa");
+			assert.equal(capabilities[1].interface, "Alexa.PowerController");
+			assert.equal(capabilities[2].interface, "Alexa.BrightnessController");
+			assert.equal(capabilities[3].interface, "Alexa.ColorController");
+
+			capabilities = endpoints[1].capabilities;
+			assert.equal(capabilities.length, 4);
+			assert.equal(capabilities[0].interface, "Alexa");
+			assert.equal(capabilities[1].interface, "Alexa.PowerController");
+			assert.equal(capabilities[2].interface, "Alexa.BrightnessController");
+			assert.equal(capabilities[3].interface, "Alexa.ColorController");
+
+			capabilities = endpoints[2].capabilities;
+			assert.equal(capabilities.length, 2);
+			assert.equal(capabilities[0].interface, "Alexa");
+			assert.equal(capabilities[1].interface, "Alexa.PowerController");
+		});
+
 		it('single color light should be discovered', function () {
 			
 			input = [
@@ -34,6 +109,7 @@ describe('ohConnectorV3 Test', function () {
 
 			var endpoints = capture.result.event.payload.endpoints;
 			assert.equal(endpoints.length, 1);
+
 			var capabilities = endpoints[0].capabilities;
 			assert.equal(capabilities.length, 4);
 			assert.equal(capabilities[0].interface, "Alexa");


### PR DESCRIPTION
A group of lights like this

```
Group:Switch:OR(ON,OFF) lightGroup ["Lighting"]
Color light1 (lightGroup) ["Lighting"]
Color light2 (lightGroup) ["Lighting"]
```
is not discovered correctly. In v2, the individual lights as well as the group of lights are discovered. In v3, only the individual lights are discovered.

I guess we have to distinguish between "endpoint" groups like e.g., Alexa.Endpoint.Thermostat or Alexa.Endpoint.Speaker and "simple" groups like a group of lights or rollershutter items.

What do you think?